### PR TITLE
Update bdf_to_h.py - fix syntax error in generated .h files

### DIFF
--- a/bdf_to_h.py
+++ b/bdf_to_h.py
@@ -397,7 +397,7 @@ for file in list(resources):
 		outstr += '#ifdef __cplusplus\n'
 		outstr += 'extern "C" {\n'
 		outstr += '#endif\n\n'
-		outstr += 'extern const packedbdf_t '+font_name+'\n\n'
+		outstr += 'extern const packedbdf_t '+font_name+';\n\n'
 		outstr += '#ifdef __cplusplus\n'
 		outstr += '}\n'
 		outstr += '#endif\n\n'


### PR DESCRIPTION
The generated .h files were missing a semicolon at the end of the line